### PR TITLE
Add an MCP Vault engagement game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "lodash": "^4.17.21",
         "lucide-react": "^0.525.0",
         "next-auth": "^5.0.0-beta.29",
@@ -1665,6 +1666,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5621,10 +5637,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -6392,6 +6411,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "lodash": "^4.17.21",
     "lucide-react": "^0.525.0",
     "next-auth": "^5.0.0-beta.29",

--- a/src/app/_components/Modal.tsx
+++ b/src/app/_components/Modal.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react';
+import { Button } from './Button';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}
+
+export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Modal */}
+      <div className="relative bg-white rounded-lg shadow-xl max-w-md w-full mx-4 max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6">{children}</div>
+
+        {/* Footer */}
+        <div className="flex justify-end p-6 border-t border-gray-200">
+          <Button onClick={onClose} variant="primary">
+            Got it
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/vault/route.ts
+++ b/src/app/api/vault/route.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { NextResponse } from 'next/server';
+import { handleRequest } from '@/lib/handle-request';
+import { Vault } from '@/server/models/vault';
+import { VaultGuess } from '@/server/models/vault-guess';
+
+export const GET = handleRequest(async () => {
+  // Get the latest vault
+  const vault = await Vault.findOne({
+    order: [['createdAt', 'DESC']],
+  });
+  if (!vault) {
+    return NextResponse.json({ error: 'No vault info currently available' }, { status: 404 });
+  }
+
+  // Get all guessed keys for this vault
+  const vaultGuesses = (await VaultGuess.findAll({
+    attributes: ['key'],
+    where: {
+      vaultId: vault.id,
+    },
+  })) as Pick<VaultGuess, 'key'>[];
+
+  // Get the winning vault guess if it exists
+  const winningVaultGuess =
+    (vault.winningVaultGuessId &&
+      (await VaultGuess.findOne({
+        where: {
+          id: vault.winningVaultGuessId,
+        },
+      }))) ||
+    null;
+
+  // Return the vault info without exposing the key
+  return NextResponse.json({
+    data: {
+      name: vault.name,
+      value: vault.value,
+      min: vault.min,
+      max: vault.max,
+      guesses: vaultGuesses.map(guess => guess.key),
+      winningVaultGuess: winningVaultGuess?.key,
+    },
+  });
+});

--- a/src/app/lib/vault.ts
+++ b/src/app/lib/vault.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAxios, handleAxiosError } from './axios';
+
+export const useVault = () => {
+  const axios = getAxios();
+
+  const query = useQuery({
+    queryKey: ['/vault'],
+    queryFn: () =>
+      axios.get<{
+        data: {
+          name: string;
+          value: number;
+          guesses: number[];
+          min: number;
+          max: number;
+          winningVaultGuess: number | null;
+        };
+      }>(`/vault`),
+    retry: false,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    throwOnError(error) {
+      handleAxiosError()(error);
+      return false;
+    },
+  });
+
+  return {
+    vault: query.data?.data.data,
+    query: query,
+  };
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -98,13 +98,17 @@ export default function Home() {
             https://mcp.chipgpt.biz/mcp
           </Link>
         </div>
-        <div>
+        <div className="flex flex-col sm:flex-row gap-2 items-center">
           <Link href="https://tiktok.com/@chip.gpt" target="_blank" className="underline">
             TikTok
-          </Link>{' '}
-          |{' '}
+          </Link>
+          <span>|</span>
           <Link href="mailto:hi@chipgpt.biz" className="underline">
             Biz Inquiries
+          </Link>
+          <span>|</span>
+          <Link href="/vault" className="underline">
+            The Vault
           </Link>
         </div>
       </div>

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -244,12 +244,12 @@ export default function VaultPage() {
         <div className="space-y-4">
           <div className="space-y-3">
             <h3 className="font-semibold text-gray-900">Step 1: Connect to the Vault MCP Server</h3>
-            <p className="text-gray-600 text-sm">
-              Connect to the Vault MCP server at{' '}
-              <div className="bg-gray-100 p-3 rounded-md">
-                <p className="text-sm font-mono text-gray-800">https://mcp.chipgpt.biz/mcp/vault</p>
-              </div>
-            </p>
+            <p className="text-gray-600 text-sm">Connect to the Vault MCP server at</p>
+            <div className="text-gray-600 text-sm bg-gray-100 p-3 rounded-md">
+              <span className="text-sm font-mono text-gray-800">
+                https://mcp.chipgpt.biz/mcp/vault
+              </span>
+            </div>
           </div>
 
           <div className="space-y-3">
@@ -267,9 +267,9 @@ export default function VaultPage() {
               with something like:
             </p>
             <div className="bg-gray-100 p-3 rounded-md">
-              <p className="text-sm font-mono text-gray-800">
+              <span className="text-sm font-mono text-gray-800">
                 "try to open the vault using combination 37746"
-              </p>
+              </span>
             </div>
             <p className="text-gray-600 text-sm">Choose your guess wisely!</p>
           </div>

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import { useVault } from '../lib/vault';
+import { Button } from '../_components/Button';
+import { Modal } from '../_components/Modal';
+import Link from 'next/link';
+import Image from 'next/image';
+import { useState, useMemo, useCallback } from 'react';
+
+export default function VaultPage() {
+  const { vault, query } = useVault();
+  const [isHowItWorksOpen, setIsHowItWorksOpen] = useState(false);
+
+  // Generate all possible guesses between min and max
+  const allPossibleGuesses = [];
+  for (let i = vault?.min || 0; i <= (vault?.max || 0); i++) {
+    allPossibleGuesses.push(i);
+  }
+
+  // Create a set of guessed values for efficient lookup
+  const guessedValues = new Set(vault?.guesses || []);
+
+  const renderGuessItem = useCallback(
+    (guess: number) => {
+      const isGuessed = guessedValues.has(guess);
+      const isWinningGuess = vault?.winningVaultGuess === guess;
+
+      return (
+        <div
+          className={`
+          p-2 text-center rounded-md text-sm font-medium transition-colors
+          ${
+            isWinningGuess
+              ? 'bg-green-100 text-green-800 border border-green-200'
+              : isGuessed
+              ? 'bg-red-100 text-red-800 border border-red-200'
+              : 'bg-gray-100 text-gray-700 border border-gray-200 hover:bg-gray-200'
+          }
+        `}
+          title={
+            isWinningGuess
+              ? `WINNER: ${guess}`
+              : isGuessed
+              ? `Guessed: ${guess}`
+              : `Available: ${guess}`
+          }
+        >
+          {guess}
+        </div>
+      );
+    },
+    [guessedValues, vault?.winningVaultGuess]
+  );
+
+  if (query.isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading vault information...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-md mx-auto p-6">
+          <div className="mb-6">
+            <Image
+              alt="ChipGPT"
+              className="rounded-full mx-auto"
+              width={80}
+              height={80}
+              src="/chipgpt-logo.png"
+            />
+          </div>
+          <h1 className="text-2xl font-bold mb-4">Vault Unavailable</h1>
+          <p className="text-gray-600 mb-6">
+            {query.error?.message || 'No vault is currently available to open.'}
+          </p>
+          <Link href="/">
+            <Button>Return Home</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!vault) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center max-w-md mx-auto p-6">
+          <div className="mb-6">
+            <Image
+              alt="ChipGPT"
+              className="rounded-full mx-auto"
+              width={80}
+              height={80}
+              src="/chipgpt-logo.png"
+            />
+          </div>
+          <h1 className="text-2xl font-bold mb-4">No Vault Found</h1>
+          <p className="text-gray-600 mb-6">There is currently no vault available to display.</p>
+          <Link href="/">
+            <Button>Return Home</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto p-6">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="mb-4">
+            <Image
+              alt="ChipGPT"
+              className="rounded-full mx-auto"
+              width={80}
+              height={80}
+              src="/chipgpt-logo.png"
+            />
+          </div>
+          <h1 className="text-3xl font-bold mb-2">Vault Information</h1>
+          <p className="text-gray-600">Current vault status and details</p>
+        </div>
+
+        {/* Winning Guess Display */}
+        {vault.winningVaultGuess && (
+          <div className="bg-gradient-to-r from-green-500 to-green-600 text-white rounded-lg shadow-lg p-6 mb-6 text-center">
+            <div className="mb-2">
+              <span className="text-2xl font-bold">🎉 WINNER! 🎉</span>
+            </div>
+            <div className="text-4xl font-bold mb-2">{vault.winningVaultGuess}</div>
+            <p className="text-green-100 text-lg">The vault has been unlocked!</p>
+          </div>
+        )}
+
+        {/* Vault Details Card */}
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <h2 className="text-xl font-semibold mb-4">Vault Details</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Vault Name</label>
+              <p className="text-lg font-semibold text-gray-900">{vault.name}</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Vault Value</label>
+              <p className="text-lg font-semibold text-green-600">
+                ${vault.value.toLocaleString()}
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Minimum Guess</label>
+              <p className="text-lg font-semibold text-gray-900">{vault.min}</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Maximum Guess</label>
+              <p className="text-lg font-semibold text-gray-900">{vault.max}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Action Buttons and Last Updated */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-6 w-full">
+          <div className="flex justify-center gap-4">
+            <Button
+              onClick={() => query.refetch()}
+              disabled={query.isRefetching}
+              className="flex items-center justify-center gap-2"
+            >
+              {query.isRefetching ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                  Refreshing...
+                </>
+              ) : (
+                'Refresh Data'
+              )}
+            </Button>
+            <Button
+              onClick={() => setIsHowItWorksOpen(true)}
+              variant="ghost"
+              className="flex items-center justify-center gap-2 border border-black text-black hover:bg-black hover:text-white"
+            >
+              How it Works
+            </Button>
+          </div>
+        </div>
+
+        {/* Last Updated */}
+        <div className="text-center mb-6 text-sm text-gray-500">
+          Last updated: {new Date().toLocaleString()}
+        </div>
+
+        {/* All Possible Guesses Card */}
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          <h2 className="text-xl font-semibold mb-4">All Possible Guesses</h2>
+          <div className="mb-4">
+            <p className="text-sm text-gray-600 mb-2">
+              Showing all possible guesses from {vault.min} to {vault.max}
+            </p>
+            <p className="text-sm text-gray-600">
+              Guessed: {vault.guesses.length} | Remaining:{' '}
+              {allPossibleGuesses.length - vault.guesses.length}
+            </p>
+          </div>
+
+          <div className="mb-4 flex items-center gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-green-100 border border-green-200 rounded"></div>
+              <span>Winner</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-red-100 border border-red-200 rounded"></div>
+              <span>Guessed</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 bg-gray-100 border border-gray-200 rounded"></div>
+              <span>Available</span>
+            </div>
+          </div>
+
+          <VirtualGrid
+            items={allPossibleGuesses}
+            renderItem={renderGuessItem}
+            itemHeight={40}
+            containerHeight={400}
+            columns={6}
+          />
+        </div>
+      </div>
+
+      {/* How it Works Modal */}
+      <Modal
+        isOpen={isHowItWorksOpen}
+        onClose={() => setIsHowItWorksOpen(false)}
+        title="How to Unlock the Vault"
+      >
+        <div className="space-y-4">
+          <div className="space-y-3">
+            <h3 className="font-semibold text-gray-900">Step 1: Connect to the Vault MCP Server</h3>
+            <p className="text-gray-600 text-sm">
+              Connect to the Vault MCP server at{' '}
+              <div className="bg-gray-100 p-3 rounded-md">
+                <p className="text-sm font-mono text-gray-800">https://mcp.chipgpt.biz/mcp/vault</p>
+              </div>
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="font-semibold text-gray-900">Step 2: Sign Up/Log In</h3>
+            <p className="text-gray-600 text-sm">
+              Sign up or log in to your account and verify that you are a human through the
+              authentication process.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="font-semibold text-gray-900">Step 3: Submit Your Daily Guess</h3>
+            <p className="text-gray-600 text-sm">
+              Every day, you can submit a number to try to unlock the vault. Simply prompt the AI
+              with something like:
+            </p>
+            <div className="bg-gray-100 p-3 rounded-md">
+              <p className="text-sm font-mono text-gray-800">"try to open the vault using 37746"</p>
+            </div>
+            <p className="text-gray-600 text-sm">Choose your guess wisely!</p>
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="font-semibold text-gray-900">Step 4: Track Progress</h3>
+            <p className="text-gray-600 text-sm">
+              Visit the website{' '}
+              <Link
+                href="https://chipgpt.biz/vault"
+                target="_blank"
+                className="text-blue-600 hover:underline"
+              >
+                https://chipgpt.biz/vault
+              </Link>{' '}
+              to view which numbers have already been guessed and track the progress of the vault
+              unlocking.
+            </p>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+// Virtual Grid Component
+function VirtualGrid({
+  items,
+  renderItem,
+  itemHeight = 40,
+  containerHeight = 400,
+  columns = 12,
+}: {
+  items: any[];
+  renderItem: (item: any, index: number) => React.ReactNode;
+  itemHeight?: number;
+  containerHeight?: number;
+  columns?: number;
+}) {
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const rowsPerView = Math.ceil(containerHeight / itemHeight);
+  const totalRows = Math.ceil(items.length / columns);
+
+  const startRow = Math.floor(scrollTop / itemHeight);
+  const endRow = Math.min(startRow + rowsPerView + 1, totalRows);
+
+  const visibleItems = useMemo(() => {
+    const startIndex = startRow * columns;
+    const endIndex = Math.min(endRow * columns, items.length);
+    return items.slice(startIndex, endIndex);
+  }, [items, startRow, endRow, columns]);
+
+  const totalHeight = totalRows * itemHeight;
+
+  const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    setScrollTop(e.currentTarget.scrollTop);
+  }, []);
+
+  return (
+    <div
+      className="overflow-auto border border-gray-200 rounded-md w-full"
+      style={{ height: containerHeight }}
+      onScroll={handleScroll}
+    >
+      <div style={{ height: totalHeight, position: 'relative', width: '100%' }}>
+        <div
+          style={{
+            position: 'absolute',
+            top: startRow * itemHeight,
+            left: 0,
+            right: 0,
+            width: '100%',
+          }}
+        >
+          <div
+            className="grid gap-2 w-full"
+            style={{
+              gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+              height:
+                visibleItems.length > 0 ? Math.ceil(visibleItems.length / columns) * itemHeight : 0,
+            }}
+          >
+            {visibleItems.map((item, index) => {
+              const actualIndex = startRow * columns + index;
+              return (
+                <div key={actualIndex} style={{ height: itemHeight, minWidth: 0 }}>
+                  {renderItem(item, actualIndex)}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/vault/page.tsx
+++ b/src/app/vault/page.tsx
@@ -267,7 +267,9 @@ export default function VaultPage() {
               with something like:
             </p>
             <div className="bg-gray-100 p-3 rounded-md">
-              <p className="text-sm font-mono text-gray-800">"try to open the vault using 37746"</p>
+              <p className="text-sm font-mono text-gray-800">
+                "try to open the vault using combination 37746"
+              </p>
             </div>
             <p className="text-gray-600 text-sm">Choose your guess wisely!</p>
           </div>

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -118,14 +118,14 @@ export function registerTools(server: McpServer, userSession?: ISession) {
 export function registerVaultTools(server: McpServer, userSession?: ISession) {
   if (userSession?.scope.includes('write')) {
     server.registerTool(
-      'submit-vault-key',
+      'submit-vault-combination',
       {
-        title: 'Submit Vault Key',
-        description: `This tool submits a key to try to unlock the vault.`,
+        title: 'Submit Vault Combination',
+        description: `This tool submits a combination to try to unlock the vault.`,
         inputSchema: {
-          key: z
+          combination: z
             .number({
-              description: 'The key being submitted by the user to try to unlock the vault',
+              description: 'The combination being submitted by the user to try to unlock the vault',
             })
             .int()
             .min(1)
@@ -160,7 +160,7 @@ export function registerVaultTools(server: McpServer, userSession?: ISession) {
             // It will be rejected if the key has already been submitted this vault
             // It will be rejected if the user has already submitted a guess for today
             const vaultGuess = await VaultGuess.create({
-              key: input.key,
+              key: input.combination,
               hour: format(new Date(), 'yyyy-MM-dd HH'),
               vaultId: vault.id,
               userId: userSession.userId,
@@ -180,7 +180,7 @@ export function registerVaultTools(server: McpServer, userSession?: ISession) {
               // @ts-ignore - Sequelize types are not correct - `error.parent.constraint` is not typed
               if (error.parent.constraint === 'VaultGuesses_vaultId_userId_hour_unique') {
                 throw new SafeError(
-                  `You have already submitted a guess for today to this vault. You can submit again at ${startOfHour(
+                  `You have already submitted a guess for this hour to this vault. You can submit again at ${startOfHour(
                     addHours(new Date(), 1)
                   ).toISOString()}`
                 );
@@ -189,7 +189,7 @@ export function registerVaultTools(server: McpServer, userSession?: ISession) {
               // @ts-ignore - Sequelize types are not correct - `error.parent.constraint` is not typed
               if (error.parent.constraint === 'VaultGuesses_vaultId_key_unique') {
                 throw new SafeError(
-                  `That key has already been submitted to this vault. Try a different key.`
+                  `That combination has already been submitted to this vault. Try a different combination.`
                 );
               }
             }

--- a/src/server/mcp/tools.ts
+++ b/src/server/mcp/tools.ts
@@ -5,7 +5,12 @@ import { User } from '../models/user';
 import { MissingReadScopeError, MissingWriteScopeError, SafeError } from './errors';
 import { z } from 'zod';
 import { userProfileOutputSchema } from './schemas';
+import { VaultGuess } from '../models/vault-guess';
+import { Vault } from '../models/vault';
+import { addHours, format, startOfHour } from 'date-fns';
+import { UniqueConstraintError } from 'sequelize';
 
+// These resources are available when accessing /mcp
 export function registerResources(server: McpServer, userSession?: ISession) {
   if (userSession?.scope.includes('read')) {
     server.registerResource(
@@ -30,7 +35,6 @@ export function registerResources(server: McpServer, userSession?: ISession) {
               context: userSession.user.profile.context,
             },
           };
-
           return {
             contents: [
               {
@@ -45,6 +49,7 @@ export function registerResources(server: McpServer, userSession?: ISession) {
   }
 }
 
+// These tools are available when accessing /mcp
 export function registerTools(server: McpServer, userSession?: ISession) {
   if (userSession?.scope.includes('read')) {
     server.registerTool(
@@ -61,24 +66,14 @@ export function registerTools(server: McpServer, userSession?: ISession) {
             throw new MissingWriteScopeError();
           }
 
-          const content = {
+          return createToolResponse({
             profile: {
               id: userSession.user.id,
               name: userSession.user.name,
               email: userSession.user.email,
               context: userSession.user.profile.context,
             },
-          };
-
-          return {
-            structuredContent: content,
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify(content),
-              },
-            ],
-          };
+          });
         })
     );
   }
@@ -113,19 +108,96 @@ export function registerTools(server: McpServer, userSession?: ISession) {
 
           server.sendResourceListChanged();
 
-          const content = {
-            success: true,
-          };
+          return createToolResponse({ success: true });
+        })
+    );
+  }
+}
 
-          return {
-            structuredContent: content,
-            content: [
-              {
-                type: 'text' as const,
-                text: JSON.stringify(content),
-              },
-            ],
-          };
+// These tools are available when accessing /mcp/vault
+export function registerVaultTools(server: McpServer, userSession?: ISession) {
+  if (userSession?.scope.includes('write')) {
+    server.registerTool(
+      'submit-vault-key',
+      {
+        title: 'Submit Vault Key',
+        description: `This tool submits a key to try to unlock the vault.`,
+        inputSchema: {
+          key: z
+            .number({
+              description: 'The key being submitted by the user to try to unlock the vault',
+            })
+            .int()
+            .min(1)
+            .max(999999),
+        },
+        outputSchema: {
+          success: z.boolean({ description: 'Whether or not the vault was successfully unlocked' }),
+        },
+      },
+      async input =>
+        handleToolRequest(async () => {
+          if (!userSession.scope.includes('write')) {
+            throw new MissingWriteScopeError();
+          }
+
+          // Get the latest vault that is not opened
+          const vault = await Vault.findOne({
+            where: {
+              openedAt: null,
+              winningVaultGuessId: null,
+            },
+            order: [['createdAt', 'DESC']],
+          });
+          if (!vault) {
+            throw new SafeError('No vault currently available to open');
+          }
+
+          // Submit the guess to the database
+          let success = false;
+          try {
+            // Create the vault guess for today
+            // It will be rejected if the key has already been submitted this vault
+            // It will be rejected if the user has already submitted a guess for today
+            const vaultGuess = await VaultGuess.create({
+              key: input.key,
+              hour: format(new Date(), 'yyyy-MM-dd HH'),
+              vaultId: vault.id,
+              userId: userSession.userId,
+            });
+
+            // If the guess is correct, update the vault `openedAt` and set the `winningVaultGuessId`
+            if (vaultGuess.key === vault.key) {
+              await vault.update({
+                openedAt: new Date(),
+                winningVaultGuessId: vaultGuess.id,
+              });
+              success = true;
+            }
+          } catch (error) {
+            if (error instanceof UniqueConstraintError) {
+              // User has already submitted a guess for today for this vault
+              // @ts-ignore - Sequelize types are not correct - `error.parent.constraint` is not typed
+              if (error.parent.constraint === 'VaultGuesses_vaultId_userId_hour_unique') {
+                throw new SafeError(
+                  `You have already submitted a guess for today to this vault. You can submit again at ${startOfHour(
+                    addHours(new Date(), 1)
+                  ).toISOString()}`
+                );
+              }
+              // Key has already been submitted for this vault
+              // @ts-ignore - Sequelize types are not correct - `error.parent.constraint` is not typed
+              if (error.parent.constraint === 'VaultGuesses_vaultId_key_unique') {
+                throw new SafeError(
+                  `That key has already been submitted to this vault. Try a different key.`
+                );
+              }
+            }
+            // Some unknown sequelize error
+            throw error;
+          }
+
+          return createToolResponse({ success });
         })
     );
   }
@@ -143,4 +215,16 @@ export async function getUser(userSession: ISession) {
     );
   }
   return { user: user };
+}
+
+function createToolResponse<T extends Object>(content: T) {
+  return {
+    structuredContent: content,
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(content),
+      },
+    ],
+  };
 }

--- a/src/server/models/index.ts
+++ b/src/server/models/index.ts
@@ -9,6 +9,8 @@ import { InitOAuthAccessTokenModel } from './oauth-access-token';
 import { InitOAuthAuthorizationCodeModel } from './oauth-authorization-code';
 import { InitSessionModel } from './session';
 import { InitVerificationTokenModel } from './verification-token';
+import { InitVaultModel } from './vault';
+import { InitVaultGuessModel } from './vault-guess';
 
 export const getSequelizeConnection = once((lambda: boolean) => {
   const connectionOptions: Options = {
@@ -74,6 +76,8 @@ export const getSequelizeConnection = once((lambda: boolean) => {
   const OAuthAccessToken = InitOAuthAccessTokenModel(sequelize);
   const OAuthAuthorizationCode = InitOAuthAuthorizationCodeModel(sequelize);
   const Session = InitSessionModel(sequelize);
+  const Vault = InitVaultModel(sequelize);
+  const VaultGuess = InitVaultGuessModel(sequelize);
 
   User.hasMany(Account, { foreignKey: 'userId', as: 'accounts' });
   Account.belongsTo(User, { foreignKey: 'userId', as: 'user' });
@@ -95,6 +99,9 @@ export const getSequelizeConnection = once((lambda: boolean) => {
 
   User.hasMany(Session, { foreignKey: 'userId', as: 'sessions' });
   Session.belongsTo(User, { foreignKey: 'userId', as: 'user' });
+
+  Vault.hasMany(VaultGuess, { foreignKey: 'vaultId', as: 'valueGuesses' });
+  VaultGuess.belongsTo(Vault, { foreignKey: 'vaultId', as: 'vault' });
 
   InitVerificationTokenModel(sequelize);
 

--- a/src/server/models/vault-guess.ts
+++ b/src/server/models/vault-guess.ts
@@ -1,0 +1,53 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+
+export interface IVaultGuess {
+  id: string;
+  key: number;
+  hour: string;
+  vaultId: string;
+  userId: string;
+}
+
+export class VaultGuess extends Model implements IVaultGuess {
+  declare id: string;
+  declare key: number;
+  declare hour: string;
+  declare vaultId: string;
+  declare userId: string;
+}
+
+export function InitVaultGuessModel(sequelize: Sequelize) {
+  const VaultGuessModel = VaultGuess.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      key: { type: DataTypes.INTEGER, allowNull: false },
+      hour: { type: DataTypes.TEXT, allowNull: false },
+      vaultId: { type: DataTypes.UUID, allowNull: false },
+      userId: { type: DataTypes.UUID, allowNull: false },
+    },
+    {
+      sequelize: sequelize,
+      tableName: 'VaultGuesses',
+      paranoid: true,
+      indexes: [
+        // This is used to check if the user has already submitted a guess for today for this vault
+        {
+          name: 'VaultGuesses_vaultId_userId_hour_unique',
+          fields: ['vaultId', 'userId', 'hour'],
+          unique: true,
+        },
+        // This is used to check if the key has already been submitted for this vault
+        {
+          name: 'VaultGuesses_vaultId_key_unique',
+          fields: ['vaultId', 'key'],
+          unique: true,
+        },
+      ],
+    }
+  );
+  return VaultGuessModel;
+}

--- a/src/server/models/vault.ts
+++ b/src/server/models/vault.ts
@@ -1,0 +1,51 @@
+import { DataTypes, Model, Sequelize } from 'sequelize';
+
+export interface IVault {
+  id: string;
+  name: string;
+  min: number;
+  max: number;
+  key: number;
+  value: number;
+  openedAt: Date | null;
+  winningVaultGuessId: string | null;
+}
+
+export class Vault extends Model implements IVault {
+  declare id: string;
+  declare name: string;
+  declare min: number;
+  declare max: number;
+  declare key: number;
+  declare value: number;
+  declare openedAt: Date | null;
+  declare winningVaultGuessId: string | null;
+}
+
+export function InitVaultModel(sequelize: Sequelize) {
+  return Vault.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      name: { type: DataTypes.STRING, allowNull: false },
+      min: { type: DataTypes.INTEGER, allowNull: false },
+      max: { type: DataTypes.INTEGER, allowNull: false },
+      key: { type: DataTypes.INTEGER, allowNull: false },
+      value: { type: DataTypes.INTEGER, allowNull: false },
+      openedAt: { type: DataTypes.DATE, allowNull: true, defaultValue: null },
+      winningVaultGuessId: {
+        type: DataTypes.UUID,
+        allowNull: true,
+        defaultValue: null,
+      },
+    },
+    {
+      sequelize: sequelize,
+      tableName: 'Vaults',
+      paranoid: true,
+    }
+  );
+}


### PR DESCRIPTION
This PR adds a vault game where authorized users are able to guess the combination every hour using an MCP client.

> **NOTE:** If you are following this repo and using it as a base for your project, you will mostly be interested in the implementation of `express-rate-limit` for the MCP server to prevent getting overloaded by requests. Everything else here is mostly just to make a fun MCP based game.

## Changes

- Adds new `Vault` and `VaultGuess` models for the game
- Add `express-rate-limit` middleware to the MCP expressjs server
- Adds a new path to the mcp server `/mcp/vault` specifically for exposing only the vault game to the LLM
- Conditionally adds tools/resources based on the access path (`/mcp` vs `/mcp/vault`)
- Adds a handler for the new `submit-vault-combination` tool
- Adds new API route to fetch current vault information
- Adds a new `useVault()` hook to fetch the vault info
- Add a new page to the website that shows the current vault status and which numbers have been guessed
- Add a link to the new vault page on the home page `src/app/page.tsx`

<img width="965" height="863" alt="image" src="https://github.com/user-attachments/assets/76af40fd-5edb-467f-9082-32da1f5c9196" />