### PR TITLE
Add subscription paywall support using Stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,5 @@ NEXT_PUBLIC_POSTHOG_HOST=
 MAILGUN_API_KEY=
 # Sender domain for email. (Required)
 SENDER_DOMAIN=
+# Stripe client info [Required]
+STRIPE_API_KEY=

--- a/.github/workflows/prod-workflow.yml
+++ b/.github/workflows/prod-workflow.yml
@@ -64,6 +64,7 @@ jobs:
           CUSTOM_MCP_DOMAIN: mcp.chipgpt.biz
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: https://us.i.posthog.com
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
         run: |
           npm run deploy:production
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The production cloud deployment without much activity is $1-$2 per day to run on
 - Your domain should be set up in Route 53 and you will need the Hosted Zone ID for cloud deployments (not needed for local deployments).
 - IAM user access key/secret [Setup Guide](https://guide.sst.dev/chapters/create-an-iam-user.html) and [Permissions Guide](https://sst.dev/docs/iam-credentials/#iam-permissions)
 - Mailgun Account [Get API Key](https://help.mailgun.com/hc/en-us/articles/203380100-Where-can-I-find-my-API-keys-and-SMTP-credentials)
+- Stripe Account [Get API Key] (https://docs.stripe.com/keys)
 
 You can do a global find for `chipgpt` (case insensitive) and locate most things that need to be updated with your own project name and description.
 
@@ -74,7 +75,7 @@ npx sst dev
 > ✕  Unexpected error occurred. Please run with --print-logs or check .sst/log/sst.log if available.
 > ```
 
-After starting up new environments for the first time, you will need to update the newly Amazon Cognito Pool's domain in AWS console.
+After starting up new environments for the first time, you will need to update the new Amazon Cognito Pool's domain in AWS console.
 
 **Log in to AWS Console** > **Amazon Cognito** > **User Pools** > **select user pool** > **Domain** > **set a domain for your cognito pool and make sure to set "Hosted UI (classic)"**
 
@@ -136,12 +137,13 @@ To get the GitHub action deployment working you will need an IAM user with acces
 - DATABASE_URL
 - AWS_HOSTED_ZONE_ID
 - MAILGUN_API_KEY
+- STRIPE_API_KEY
 - NEXT_PUBLIC_POSTHOG_KEY (not really a "secret", it could be a variable instead)
 
 ## Things I intend to add as I add them to my own SaaS:
 
 - [x] ~~Add SES email management for production SES access~~ Add Mailgun email for sending emails
-- [ ] Add a paid account tier (most likely using Stripe as the payment gateway)
+- [x] Add a paid account tier (most likely using Stripe as the payment gateway)
 - [ ] Add a propper logging utility that works better with AWS CloudWatch.
 - [ ] Add Alarms/Alerts for cloud deployments to be proactive about issues.
 - [ ] Auto-Generate REST API Documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "sequelize": "^6.37.5",
         "sharp": "^0.33.5",
         "sst": "3.9.27",
+        "stripe": "^18.3.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
         "uuid": "^11.0.3",
@@ -9992,6 +9993,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.4.0.tgz",
+      "integrity": "sha512-LKFeDnDYo4U/YzNgx2Lc9PT9XgKN0JNF1iQwZxgkS4lOw5NunWCnzyH5RhTlD3clIZnf54h7nyMWkS8VXPmtTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "recharts": "^2.15.3",
     "sequelize": "^6.37.5",
     "sharp": "^0.33.5",
+    "stripe": "^18.3.0",
     "sst": "3.9.27",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/src/app/api/billing/route.ts
+++ b/src/app/api/billing/route.ts
@@ -1,0 +1,79 @@
+import { auth } from '@/auth';
+import { handleRequest } from '@/lib/handle-request';
+import { User } from '@/server/models/user';
+import {
+  createCheckoutSession,
+  createCustomer,
+  createManagementSession,
+  getSubscriptions,
+} from '@/server/utils/stripe';
+import { NextResponse } from 'next/server';
+import { Resource } from 'sst';
+
+const isValidStripePlan = (
+  plan: string | null
+): plan is keyof typeof Resource.MyStripePlans.plans => {
+  return !!plan && plan in Resource.MyStripePlans.plans;
+};
+
+const isValidStripeCoupon = (
+  plan: string | null
+): plan is keyof typeof Resource.MyStripePlans.coupons => {
+  return !!plan && plan in Resource.MyStripePlans.coupons;
+};
+
+/**
+ * Redirects to the Stripe checkout page or billing portal depending on the customer's current plan.
+ */
+export const GET = handleRequest(async req => {
+  let priceId = '';
+  let coupon = '';
+
+  const plan = req.nextUrl.searchParams.get('plan') || 'starter';
+  if (isValidStripePlan(plan)) {
+    priceId = Resource.MyStripePlans.plans[plan];
+  }
+  if (isValidStripeCoupon(plan)) {
+    coupon = Resource.MyStripePlans.coupons[plan];
+  }
+
+  const session = await auth();
+  if (!session?.user) return NextResponse.json({ error: 'Unauthenticated' }, { status: 401 });
+
+  // Create a Stripe customer if the user doesn't have one
+  if (!session.user.stripeCustomerId) {
+    const customer = await createCustomer(session.user);
+    await User.update(
+      { stripeCustomerId: customer.id },
+      { where: { id: session.user.id }, fields: ['stripeCustomerId'] }
+    );
+    session.user.stripeCustomerId = customer.id;
+  }
+
+  // Check if the user has ever had a subscription
+  const subscriptions = await getSubscriptions(session.user.stripeCustomerId, true);
+  if (subscriptions.length > 0) {
+    // If the user has a previous subscription, they cannot use a coupon again
+    coupon = '';
+  }
+
+  // If the user has a plan, redirect to the billing portal
+  if (session.user.plan) {
+    const managementSession = await createManagementSession(session.user.stripeCustomerId);
+    return NextResponse.redirect(managementSession.url);
+  }
+  // If the user doesn't have a plan, create a checkout session
+  else if (session.user.stripeCustomerId) {
+    const checkoutSession = await createCheckoutSession(
+      session.user.stripeCustomerId,
+      priceId,
+      coupon,
+      session.user.id
+    );
+    if (checkoutSession.url) {
+      return NextResponse.redirect(checkoutSession.url);
+    }
+  }
+
+  return NextResponse.json({ error: 'Unable to access billing at this time' }, { status: 400 });
+});

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { CreditCardIcon, CrownIcon } from 'lucide-react';
 import { useSession } from 'next-auth/react';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 
 export default function DashboardPage() {
@@ -14,6 +16,19 @@ export default function DashboardPage() {
     return <div>Logging in...</div>;
   }
 
+  // Get current plan information
+  const currentPlan = session.data?.user?.plan || null;
+  const getPlanInfo = (plan: string | null) => {
+    switch (plan) {
+      case 'starter':
+        return { name: 'Starter', price: '$9/mo', gradient: 'from-green-500 to-emerald-500' };
+      default:
+        return { name: 'Free', price: '$0/mo', gradient: 'from-gray-500 to-slate-500' };
+    }
+  };
+
+  const planInfo = getPlanInfo(currentPlan);
+
   return (
     <div className="min-h-screen relative overflow-hidden">
       <div className="relative z-10 p-6">
@@ -24,6 +39,31 @@ export default function DashboardPage() {
             <p className="text-gray-400 mt-1">
               Welcome to the dashboard, you are logged in as {session.data?.user?.email}
             </p>
+          </div>
+        </section>
+
+        {/* Subscription Plan Section */}
+        <section className="mb-8">
+          <div className="border rounded-2xl p-3 sm:p-6">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4">
+                <div className={`p-3 rounded-xl bg-gradient-to-br ${planInfo.gradient}`}>
+                  <CrownIcon className="w-6 h-6 text-white" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold">{planInfo.name} Plan</h3>
+                  <p className="text-gray-400 text-sm">{planInfo.price}</p>
+                </div>
+              </div>
+              <Link
+                href="/api/billing"
+                className="group flex items-center gap-2 px-4 py-2 border rounded-lg transition-all duration-300 hover:scale-105"
+              >
+                <CreditCardIcon className="w-4 h-4" />
+                <span className="text-sm">Manage</span>
+                <div className="absolute inset-0 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+              </Link>
+            </div>
           </div>
         </section>
       </div>

--- a/src/app/webhook/stripe/route.ts
+++ b/src/app/webhook/stripe/route.ts
@@ -1,0 +1,92 @@
+import { handleRequest } from '@/lib/handle-request';
+import { CONFIG } from '@/server/config';
+import { User } from '@/server/models/user';
+import { getCheckoutSession } from '@/server/utils/stripe';
+import { Resource } from 'sst';
+import { NextResponse } from 'next/server';
+import stripe from 'stripe';
+
+/**
+ * Handles the Stripe callback for checkout sessions.
+ * Updates the user's plan based on the completed checkout session.
+ */
+export const GET = handleRequest(async req => {
+  const checkoutSessionId = req.nextUrl.searchParams.get('checkoutSessionId');
+  if (checkoutSessionId) {
+    const session = await getCheckoutSession(checkoutSessionId);
+    if (
+      session.status === 'complete' &&
+      session.customer &&
+      typeof session.customer !== 'string' &&
+      !session.customer.deleted &&
+      session.subscription &&
+      typeof session.subscription !== 'string'
+    ) {
+      const user = await User.findOne({
+        where: { stripeCustomerId: session.customer.id },
+      });
+      if (user) {
+        if (!user.email) {
+          await user.update({ email: session.customer.email }, { fields: ['email'] });
+        }
+        const priceId = session.subscription.items.data.find(Boolean)?.price?.id;
+        if (priceId) {
+          await updateUserPlan(user, priceId);
+        }
+      }
+    }
+  }
+  return NextResponse.redirect(`${CONFIG.website}/dashboard`);
+});
+
+/**
+ * Handles the Stripe webhook for subscription updates.
+ */
+export const POST = handleRequest(async req => {
+  const event = stripe.webhooks.constructEvent(
+    await req.text(),
+    req.headers.get('stripe-signature') || '',
+    Resource.MyStripePlans.webhookSecret
+  );
+
+  if (
+    event.type === 'customer.subscription.created' ||
+    event.type === 'customer.subscription.updated' ||
+    event.type === 'customer.subscription.deleted'
+  ) {
+    const subscription = event.data.object;
+    const user = await User.findOne({ where: { stripeCustomerId: subscription.customer } });
+
+    if (user) {
+      // Update the user's plan when the subscription is created or updated.
+      if (
+        event.type === 'customer.subscription.created' ||
+        event.type === 'customer.subscription.updated'
+      ) {
+        const priceId = subscription.items.data.find(Boolean)?.price?.id;
+        if (priceId) {
+          await updateUserPlan(user, priceId);
+        }
+      }
+      // Set the user's plan to null when the subscription is deleted.
+      else {
+        user.plan = null;
+        await user.save({ fields: ['plan'] });
+      }
+    }
+  }
+
+  return NextResponse.json({});
+});
+
+/**
+ * Updates the user's plan based on the price ID.
+ */
+async function updateUserPlan(user: User, priceId: string) {
+  if (priceId === Resource.MyStripePlans.plans.starter) {
+    user.plan = 'starter';
+    await user.save({ fields: ['plan'] });
+  } else {
+    console.error('Unknown plan:', priceId);
+  }
+}

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,15 +1,24 @@
-import { NextAuthConfig } from 'next-auth';
+import { DefaultSession, NextAuthConfig } from 'next-auth';
 import Cognito from 'next-auth/providers/cognito';
 import { Resource } from 'sst';
 import { Sequelize } from 'sequelize';
 import { CONFIG } from './server/config';
 import pg from 'pg';
-import { InitUserModel } from './server/models/user';
+import { InitUserModel, IUser } from './server/models/user';
 import { InitAccountModel } from './server/models/account';
 import SequelizeAdapter from './lib/@auth/sequelize-adapter';
 import { InitSessionModel } from './server/models/session';
 import { InitVerificationTokenModel } from './server/models/verification-token';
 import { sendMailgunEmail } from './server/utils/mailgun';
+
+declare module 'next-auth' {
+  /**
+   * Returned by `auth`, `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
+   */
+  interface Session {
+    user: IUser & DefaultSession['user'];
+  }
+}
 
 export const nextAuthConfig: NextAuthConfig = {
   callbacks: {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -11,6 +11,7 @@ interface IConfig {
   aws: {
     region: string;
   };
+  website: string;
 }
 
 export const CONFIG: IConfig = {
@@ -20,8 +21,7 @@ export const CONFIG: IConfig = {
     url: new URL(process.env.DATABASE_URL || 'postgres://username:password@localhost:5432/dbname'),
   },
   oauth: {
-    authorizationServer:
-      process.env.NODE_ENV === 'production' ? 'https://chipgpt.biz' : 'http://localhost:3000',
+    authorizationServer: process.env.WEB_URL || 'http://localhost:3000',
   },
   posthog: {
     apiKey: process.env.NEXT_PUBLIC_POSTHOG_KEY || '',
@@ -30,4 +30,5 @@ export const CONFIG: IConfig = {
   aws: {
     region: process.env.AWS_REGION || 'us-east-1',
   },
+  website: process.env.WEB_URL || 'http://localhost:3000',
 };

--- a/src/server/models/user.ts
+++ b/src/server/models/user.ts
@@ -11,6 +11,8 @@ export interface IUser {
   emailVerified: Date;
   image: string;
   profile: IUserProfile;
+  plan: string | null;
+  stripeCustomerId: string | null;
 }
 
 export class User extends Model implements IUser {
@@ -20,6 +22,8 @@ export class User extends Model implements IUser {
   declare emailVerified: Date;
   declare image: string;
   declare profile: IUserProfile;
+  declare plan: string | null;
+  declare stripeCustomerId: string | null;
 }
 
 export function InitUserModel(sequelize: Sequelize) {
@@ -38,6 +42,16 @@ export function InitUserModel(sequelize: Sequelize) {
         type: DataTypes.JSONB,
         allowNull: false,
         defaultValue: { context: '' },
+      },
+      plan: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+        defaultValue: null,
+      },
+      stripeCustomerId: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+        defaultValue: null,
       },
     },
     {

--- a/src/server/utils/stripe.ts
+++ b/src/server/utils/stripe.ts
@@ -1,0 +1,88 @@
+import Stripe from 'stripe';
+import { CONFIG } from '../config';
+import { Resource } from 'sst';
+
+const stripe = new Stripe(Resource.MyStripePlans.apiKey);
+
+/**
+ * Create a checkout session for a customer to create a subscription
+ */
+export async function createCheckoutSession(
+  stripeCustomerId: string,
+  priceId: string,
+  coupon?: string,
+  userId?: string | null
+) {
+  const session = await stripe.checkout.sessions.create({
+    client_reference_id: userId || undefined,
+    customer: stripeCustomerId,
+    mode: 'subscription',
+    line_items: [
+      {
+        price: priceId,
+        quantity: 1,
+      },
+    ],
+    currency: 'usd',
+    cancel_url: `${CONFIG.website}/dashboard`,
+    success_url: `${CONFIG.website}/webhook/stripe?checkoutSessionId={CHECKOUT_SESSION_ID}`,
+    discounts: coupon
+      ? [
+          {
+            coupon: coupon,
+          },
+        ]
+      : undefined,
+  });
+  return session;
+}
+
+/**
+ * Get a checkout session by its ID
+ */
+export async function getCheckoutSession(sessionId: string) {
+  const session = await stripe.checkout.sessions.retrieve(sessionId, {
+    expand: ['customer', 'subscription'],
+  });
+  return session;
+}
+
+/**
+ * Create a management session for a customer to manage their existing subscription
+ */
+export async function createManagementSession(customerId: string) {
+  const session = await stripe.billingPortal.sessions.create({
+    customer: customerId,
+    return_url: `${CONFIG.website}/dashboard`,
+  });
+  return session;
+}
+
+/**
+ * Create a customer in Stripe
+ */
+export async function createCustomer(user: { id: string; email?: string | null }) {
+  const customer = await stripe.customers.create({
+    email: user.email || undefined,
+  });
+  return customer;
+}
+
+/**
+ * Get a customer by their ID
+ */
+export async function getCustomer(id: string) {
+  const customer = await stripe.customers.retrieve(id);
+  return customer;
+}
+
+/**
+ * Get a customer's subscriptions
+ */
+export async function getSubscriptions(customerId: string, all = false) {
+  const subscription = await stripe.subscriptions.list({
+    customer: customerId,
+    status: all ? 'all' : 'active',
+  });
+  return subscription.data;
+}

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -19,6 +19,17 @@ declare module "sst" {
       "type": "sst.aws.Service"
       "url": string
     }
+    "MyStripePlans": {
+      "apiKey": string
+      "coupons": {
+        "starter": string
+      }
+      "plans": {
+        "starter": string
+      }
+      "type": "sst.sst.Linkable"
+      "webhookSecret": string
+    }
     "MyUserPool": {
       "id": string
       "type": "sst.aws.CognitoUserPool"


### PR DESCRIPTION
- Add Stripe IaC to `sst.config.ts`
- Adds `plan` and `stripeCustomerId` fields to the `User` model
- Adds a `WEB_URL` environment variable that is used for webhooks and callbacks
- Add link in `README.md` for how to get Stripe API key
- Add `stripe` npm package
- Add `POST /webhook/stripe` route that handles webhook subscription events from Stripe
- Add `GET /api/billing` route that redirects user to Stripe checkout
- Add `GET /webhook/stripe` route that handles callback after Stripe checkout
- Add subscription plan info to `dashboard/page.tsx`
- Extend `next-auth` `Session` typings to reflect our custom session data
