### PR TITLE
use node oauth authenticate

### DIFF
--- a/src/app/api/oauth/authenticate/route.ts
+++ b/src/app/api/oauth/authenticate/route.ts
@@ -1,7 +1,7 @@
 import { handleRequest } from '@/lib/handle-request';
 import { User } from '@/server/models/user';
 import { NextResponse } from 'next/server';
-import { oauthServer } from '..';
+import { oauthServer } from '@/lib/oauth';
 import { OAuthError, Request, Response } from '@node-oauth/oauth2-server';
 
 export const GET = handleRequest(async req => {

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -1,5 +1,5 @@
 import { handleRequest } from '@/lib/handle-request';
-import { oauthServer } from '..';
+import { oauthServer } from '@/lib/oauth';
 import { NextResponse } from 'next/server';
 import { Request, Response } from '@node-oauth/oauth2-server';
 import { OAuthClient } from '@/server/models/oauth-client';

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -1,7 +1,7 @@
 import { handleRequest } from '@/lib/handle-request';
 import { Request, Response } from '@node-oauth/oauth2-server';
 import { NextResponse } from 'next/server';
-import { oauthServer } from '..';
+import { oauthServer } from '@/lib/oauth';
 
 export const POST = handleRequest(async req => {
   const request = new Request({

--- a/src/app/authorize/page.tsx
+++ b/src/app/authorize/page.tsx
@@ -32,7 +32,7 @@ function OAuthAuthorize() {
     // Build new search params with selected scopes
     const params = new URLSearchParams(location.search);
     params.set('scope', selectedScopes.join(' '));
-    location.href = `/api/oauth/authorize?${params.toString()}&state=12345`;
+    location.href = `/api/oauth/authorize?${params.toString()}`;
   };
 
   const { oauthClient } = useOAuthClient({ id: searchParams.get('client_id') || '' });

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -10,6 +10,7 @@ import { OAuthClient } from '@/server/models/oauth-client';
 import { User } from '@/server/models/user';
 
 export const oauthServer = new OAuth2Server({
+  allowEmptyState: true,
   model: {
     async getClient(clientId: string, clientSecret?: string) {
       const client = await OAuthClient.findOne({
@@ -61,8 +62,8 @@ export const oauthServer = new OAuth2Server({
         expiresAt: code.expiresAt,
         redirectUri: code.redirectUri,
         scope: code.scope,
-        client: { id: code.client.id, grants: code.client.grants },
-        user: { id: code.user.id },
+        client: code.client,
+        user: code.user,
         codeChallenge: code.codeChallenge || undefined,
         codeChallengeMethod: code.codeChallengeMethod || undefined,
       };
@@ -94,8 +95,8 @@ export const oauthServer = new OAuth2Server({
         refreshToken: token.refreshToken,
         refreshTokenExpiresAt: token.refreshTokenExpiresAt,
         scope: token.scope,
-        client: { id: client.id, grants: client.grants },
-        user: { id: user.id },
+        client: client,
+        user: user,
 
         // other formats, i.e. for Zapier
         access_token: token.accessToken,
@@ -121,8 +122,8 @@ export const oauthServer = new OAuth2Server({
         accessToken: token.accessToken,
         accessTokenExpiresAt: token.accessTokenExpiresAt,
         scope: token.scope,
-        client: { id: token.client.id, grants: token.client.grants },
-        user: { id: token.user.id },
+        client: token.client,
+        user: token.user,
       };
     },
     async getRefreshToken(refreshToken: string) {
@@ -144,8 +145,8 @@ export const oauthServer = new OAuth2Server({
         refreshToken: token.refreshToken,
         refreshTokenExpiresAt: token.refreshTokenExpiresAt,
         scope: token.scope,
-        client: { id: token.client.id, grants: token.client.grants },
-        user: { id: token.user.id },
+        client: token.client,
+        user: token.user,
       };
     },
   }, // See https://github.com/oauthjs/node-oauth2-server for specification


### PR DESCRIPTION
- Move the `@node-oauth/oauth2-server` model to a shared location so the API and MCP server both use it.
- MCP server now uses the `oauthServer.authenticate()` method and returns proper headers. This fixes the oauth flow in some MCP clients like Claude.
- Update the oauth config to make the `state` param optional. I am doing this because i want the MCP server example to work in any MCP client. If you have a secured product you may not want to do this.